### PR TITLE
mod_mypanel fixes

### DIFF
--- a/administrator/modules/mod_mypanel/tmpl/default.php
+++ b/administrator/modules/mod_mypanel/tmpl/default.php
@@ -45,6 +45,7 @@ $nPages = ceil( count($items) / 9);
             foreach ($items as $item) :
                 $desc = substr(JText::_(''.strtoupper($item->title).'_XML_DESCRIPTION'), 0, 100);
                 $descExists = strpos($desc, '_XML_DESCRIPTION');
+                $title = JText::_(''.strtoupper($item->title));
                 if ($descExists !== false) $desc = JText::_('TPL_MINIMA_NODESCRIPTION');
                 // if it's a standard extension, add the class to use the sprite img instead
                 if (in_array(strtolower($item->element), $std)) {
@@ -61,7 +62,7 @@ $nPages = ceil( count($items) / 9);
         ?>
         <?php   if (!empty($class)): ?>
                 <li>
-                    <a href="<?php echo $item->link; ?>" class="<?php echo $class; ?>"><?php echo $item->alias; ?>
+                    <a href="<?php echo $item->link; ?>" class="<?php echo $class; ?>"><?php echo $title; ?>
                         <span class="extension-desc"><?php echo $desc; ?></span>
                     </a>
                 </li>

--- a/administrator/modules/mod_mypanel/tmpl/default.php
+++ b/administrator/modules/mod_mypanel/tmpl/default.php
@@ -53,9 +53,8 @@ $nPages = ceil( count($items) / 9);
                     $arrClass = explode(":", $item->img);
                     $class = "icon-48-".$arrClass[1];
                 } else {
-                    $arrImg = explode("com_", $item->element);
-                    $img = JPATH_ADMINISTRATOR."/components".$item->element."/images/icons/icon-48-".strtolower($arrImg[1]).".png";
-                    // FIXME JPATH is the wrong constant
+                	// component dev already specifies image path, so grab 48 px icon vs. 16 px
+                	$img = str_replace('16', '48', $item->img);
                     // fallback if img not found
                    if (!file_exists($img)) $class = "icon-48-generic";
                 }
@@ -68,8 +67,8 @@ $nPages = ceil( count($items) / 9);
                 </li>
         <?php else: ?>
                 <li class="ext">
-                    <img src="<?php echo $img; ?>" width="48" height="48" alt="<?php echo $item->alias; ?>" />
-                    <a href="<?php echo $item->link; ?>" class="<?php echo $class; ?>"><?php echo $item->alias; ?>
+                    <img src="<?php echo $img; ?>" width="48" height="48" alt="<?php echo $title; ?>" />
+                    <a href="<?php echo $item->link; ?>" class="<?php echo $class; ?>"><?php echo $title; ?>
                         <span class="extension-desc"><?php echo $desc; ?></span>
                     </a>
                 </li>

--- a/administrator/templates/minima/css/template.css
+++ b/administrator/templates/minima/css/template.css
@@ -921,11 +921,15 @@ BODY.error                              {   background: #ccc; }
             #panel-list li a:active     {   position: relative; top: 2px; }
 
             #panel-list li.ext a        {
-
+                                            background-image: none;
+                                            padding-left: 0;
+                                            width: 256px;
                                         }
 
             #panel-list li.ext a img    {
-
+                                            float: left;
+                                            padding-left: 15px;
+                                            padding-right: 12px;
                                         }
 
 #panel-list li .extension-desc          {


### PR DESCRIPTION
Got some fixes for mod_mypanel here for ya:

1) It seems to be common practice to have a language string "COM_PODCASTMANAGER", so instead of displaying the alias (commonly displayed as "compodcastmanager"), instead the title is pushed through JText to get the appropriate string (end result of "Podcast Manager").  Tested locally with my Podcast Manager component, Akeeba Backup, and Admin Tools all installed and all three render the correct title with this method.

2) Instead of trying to find the icon path by itself, instead, let mod_mypanel use the info the dev supplies to get the icon.  $item->img dumps either a class (core components only it would seem) or a path to the icon (3rd party components), so in the conditional you have where it's looking for the icon, I set the $img variable to do a str_replace on 16 to 48 (16 being the "normal" size icon used in core) and grab that icon, leaving the file_exists check in place just in case.

3) So now that we have the icon, it takes a little bit of trickery to make the button look right.  But, not too much ;-)
